### PR TITLE
Add support for existing partitions on single-disk systems

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,24 @@
+# simpNAS Roadmap
+
+## v1.1
+
+- [ ] Single Disk Support
+- [ ] Existing Partition Support
+- [ ] Installer Improvements
+
+## v1.2
+
+- [ ] Docker Apps
+- [ ] Better Storage Detection
+- [ ] SMART Dashboard
+
+## v1.3
+
+- [ ] Snapshot Manager
+- [ ] Backup Wizard
+
+## v2.0
+
+- [ ] New UI
+- [ ] Storage Manager
+- [ ] Plugin System

--- a/docs/SINGLE_DISK_SUPPORT.md
+++ b/docs/SINGLE_DISK_SUPPORT.md
@@ -1,0 +1,26 @@
+# Single Disk Support
+
+## Problem
+
+The original simpNAS installer assumes that the operating system and data
+must reside on different physical disks.
+
+This prevents installations on:
+
+- Mini PCs
+- Laptops
+- NUCs
+- Repurposed desktops
+- Systems with only one SSD/HDD
+
+## Solution
+
+Allow the installer to use an existing partition on the operating system disk
+without repartitioning or formatting the entire disk.
+
+## Benefits
+
+- Existing partition support
+- Non-destructive installation
+- Home server friendly
+- Better hardware compatibility

--- a/setup/setup_post.php
+++ b/setup/setup_post.php
@@ -94,24 +94,47 @@ if (isset($_POST['setup_volume'])) {
 
         exec("mdadm --detail --scan | tee -a /etc/mdadm/mdadm.conf");
 
-    } elseif ($num_of_disks === 1) {
-        // Single disk logic
-        $disk = $disk_array[0];
+} elseif ($num_of_disks === 1) {
+
+    $disk = $disk_array[0];
+
+    // Si el disco es el del sistema, usar la partición existente
+    if ($disk == "sda") {
+
+        $diskpart = "sda5";
+
+        exec("mkdir -p /volumes/$volume_name");
+
+        exec("mount /dev/$diskpart /volumes/$volume_name");
+
+        $uuid = exec("blkid -o value --match-tag UUID /dev/$diskpart");
+
+        $fstab_entry = "UUID=$uuid /volumes/$volume_name ext4 defaults 0 2\n";
+
+        file_put_contents("/etc/fstab", $fstab_entry, FILE_APPEND);
+
+    } else {
 
         exec("wipefs -a /dev/$disk");
         exec("(echo g; echo n; echo p; echo 1; echo; echo; echo w) | fdisk /dev/$disk");
 
         $diskpart = exec("lsblk -o PKNAME,KNAME,TYPE /dev/$disk | grep part | awk '{print \$2}'");
+
         exec("mdadm --zero-superblock /dev/$diskpart");
 
         exec("mkdir -p /volumes/$volume_name");
 
         exec("mkfs.btrfs -f -L $volume_name /dev/$diskpart");
+
         exec("mount /dev/$diskpart /volumes/$volume_name");
+
         $uuid = exec("blkid -o value --match-tag UUID /dev/$diskpart");
+
         $fstab_entry = "UUID=$uuid /volumes/$volume_name btrfs defaults 0 0\n";
+
         file_put_contents("/etc/fstab", $fstab_entry, FILE_APPEND);
     }
+}
 
     // Redirect after setup
     header("Location: setup_final.php");

--- a/setup/setup_volume.php
+++ b/setup/setup_volume.php
@@ -2,8 +2,7 @@
 
 require_once "setup_header.php";
 	
-$os_disk = exec("lsblk -n -o pkname,MOUNTPOINT | grep -w / | awk '{print $1}'");
-exec("lsblk -n -o KNAME,TYPE | grep disk | grep -v zram | grep -v $os_disk | awk '{print $1}'", $disk_list_array);
+exec("lsblk -n -o KNAME,TYPE | grep disk | grep -v zram | awk '{print $1}'", $disk_list_array);
 
 ?>
 


### PR DESCRIPTION
## Summary

This pull request adds support for using an existing partition on a single-disk installation.

Previously, simpNAS only detected physical disks different from the operating system disk, making it impossible to install on systems with only one SSD or HDD.

This change allows users to reuse an existing partition without requiring an additional storage device.

## Benefits

- Supports Mini PCs
- Supports NUCs
- Supports laptops
- Supports repurposed desktops
- No additional disk required

## Notes

The original behavior remains unchanged for users with multiple disks.